### PR TITLE
chore: update repo-platform template to staging@d97a3558d4c6

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,6 +1,6 @@
 # This file is managed by Vivswan/repo-platform.
 # Copier uses it to track the template source and version - do not delete.
-_commit: 1e44504
+_commit: d97a355
 _src_path: gh:Vivswan/repo-platform
 channel: staging
 description: 'Turn highlighted text into natural speech with Amazon Polly, Azure,

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
     cooldown:
       default-days: 7
     # Conventional PR titles so the commit-names/pr-title gates pass; action
-    # bumps are workflow changes, hence ci (toolchain fragments use build).
+    # bumps are workflow changes, hence ci (package-manifest entries use build).
     commit-message:
       prefix: "ci"
       include: "scope"


### PR DESCRIPTION
Automated template update from [`Vivswan/repo-platform`](https://github.com/Vivswan/repo-platform/tree/staging) (staging channel).

- Previous: `1e44504`
- New: `staging@d97a3558d4c6`

Review any merge conflicts and confirm repository-local sections were preserved before merging.

> [!NOTE]
> This branch is regenerated on every sync run; manual commits
> pushed to it are overwritten. Make fixes in a separate branch or
> after merging.