### PR TITLE
chore: update repo-platform template to staging@8816965cc340

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,6 +1,6 @@
 # This file is managed by Vivswan/repo-platform.
 # Copier uses it to track the template source and version - do not delete.
-_commit: d97a355
+_commit: '8816965'
 _src_path: gh:Vivswan/repo-platform
 channel: staging
 description: 'Turn highlighted text into natural speech with Amazon Polly, Azure,
@@ -25,5 +25,6 @@ pages_staging: true
 private: false
 project_name: Cloud Speech
 project_slug: cloud-speech
+release_auto_publish: true
 topics: chrome-extension, text-to-speech, tts, amazon-polly, azure-speech, google-cloud-tts,
     openai, wxt, react, typescript, bun

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -11,8 +11,12 @@
 
 repository:
   description: "Turn highlighted text into natural speech with Amazon Polly, Azure, Google Cloud TTS, or OpenAI: one browser extension, your own keys."
+  # homepage, topics, and private are always declared, even when empty or
+  # public: the apply manages only declared keys, so this keeps it healing
+  # out-of-band edits (an empty value declares-and-clears).
   homepage: "https://vivswan.github.io/cloud-speech/"
   topics: "chrome-extension, text-to-speech, tts, amazon-polly, azure-speech, google-cloud-tts, openai, wxt, react, typescript, bun"
+  private: false
   has_issues: true
   has_wiki: false
   has_projects: false

--- a/.github/workflows/dependabot-bun-lockfile.yml
+++ b/.github/workflows/dependabot-bun-lockfile.yml
@@ -1,0 +1,90 @@
+# This file is managed by Vivswan/repo-platform.
+# Local edits may be replaced during template updates.
+#
+# Dependabot edits bun.lock conservatively: it bumps the target package but
+# leaves stale nested entries behind (a dependency's pinned copy of a package
+# the hoisted entry already moved past), so `bun install --frozen-lockfile`
+# and typecheck fail with mixed-version errors even when every manifest
+# accepts the update. This workflow regenerates the lockfile on Dependabot's
+# own PRs, which dedupes those entries, and pushes the fix back to the PR
+# branch; an already-clean lockfile gets no commit.
+#
+# `bun install --lockfile-only` rewrites bun.lock without installing packages
+# or running lifecycle scripts, so no PR-controlled code runs next to the
+# write credential.
+#
+# Two Dependabot token subtleties. Dependabot-triggered runs read the
+# Dependabot secrets store, not the Actions one, and their default token is
+# read-only, but the job-level permissions below are honored. And a push made
+# with github.token starts no workflows, so without the REPO_PLATFORM_TOKEN
+# secret the fix lands but the PR needs a close/reopen for its checks to
+# appear; register the token as a Dependabot secret to re-run CI
+# automatically.
+
+name: Dependabot Bun Lockfile
+
+on:
+  pull_request:
+    paths: ["**/bun.lock", "**/package.json"]
+
+permissions:
+  contents: read
+
+# Dependabot force-pushes the PR branch on rebase; a superseded run's push
+# would race the new head, so only the newest run per PR and actor proceeds.
+# The actor in the group keeps the run this workflow's own fix push triggers
+# (its job skips on the actor gate) from cancelling the finishing original.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}-${{ github.actor }}
+  cancel-in-progress: true
+
+jobs:
+  dedupe:
+    # Dependabot's own pushes only, so this workflow's fix commit and human
+    # pushes cannot re-fire it, and same-repo PRs only: the token cannot push
+    # to a fork's branch.
+    if: github.actor == 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          persist-credentials: false
+      - uses: oven-sh/setup-bun@v2
+      # Every tracked lockfile, not just the root one: a repository can
+      # commit several (repo-platform itself locks each composite action's
+      # directory). '*/bun.lock' is a git pathspec, where '*' crosses '/',
+      # so it matches at any depth. Deleting before regenerating matters: bun accepts the
+      # stale lockfile as a valid resolution and keeps it, so only a
+      # from-scratch resolve drops the stale entries. The side effect is a
+      # refresh of every in-range pin, which package.json ranges and the
+      # PR's own CI still bound.
+      - name: Regenerate bun lockfiles
+        shell: bash
+        run: |
+          git ls-files -z -- 'bun.lock' '*/bun.lock' | while IFS= read -r -d '' lock; do
+            rm -- "$lock"
+            bun install --lockfile-only --ignore-scripts --cwd "$(dirname -- "$lock")"
+            # bun deletes an empty lockfile outright; keep the committed one.
+            [ -f "$lock" ] || git checkout -- "$lock"
+          done
+      - name: Commit and push the deduped lockfiles
+        shell: bash
+        env:
+          TOKEN: ${{ secrets.REPO_PLATFORM_TOKEN || github.token }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          if git diff --quiet -- 'bun.lock' '*/bun.lock'; then
+            echo "lockfiles already deduped"
+          else
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git ls-files -z -- 'bun.lock' '*/bun.lock' | xargs -0 git add --
+            # The body's [dependabot skip] keeps Dependabot rebasing and
+            # updating the PR over this commit; without it Dependabot stops
+            # touching a PR once someone else pushes to it.
+            git commit -m "build(deps): dedupe bun lockfile" -m "[dependabot skip]"
+            git push "https://x-access-token:${TOKEN}@github.com/${GITHUB_REPOSITORY}.git" HEAD:"$HEAD_REF"
+          fi

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -2,11 +2,16 @@
 # Local edits may be replaced during template updates.
 #
 # The release-please machinery: cuts releases by accumulating conventional
-# commits on main into a release PR; merging that PR tags and publishes the
-# release. Called from the repo-owned release.yml pipeline, downstream of
-# the all-green gate, so releases and release-PR refreshes only happen on a
-# green main. Repo-specific jobs before/after the release belong in
-# release.yml, wired to the outputs below.
+# commits on main into a release PR. GitHub releases are immutable once
+# published (the tag and assets freeze, a late upload gets HTTP 422), so
+# the generated release-please-config.json sets `draft` +
+# `force-tag-creation`: merging the release PR creates a DRAFT release with
+# its tag already forced at the merge SHA, and the repo-owned release.yml
+# pipeline mutates the draft (asset uploads, note edits) and publishes it
+# as its last job. Config and pipeline are both repo-owned, so a repo
+# generated before the draft flow keeps publishing directly. Called from
+# release.yml downstream of the all-green gate, so releases and release-PR
+# refreshes only happen on a green main.
 #
 # Without the REPO_PLATFORM_TOKEN secret the release PR is created by the
 # default GITHUB_TOKEN and needs a close/reopen to run its checks.
@@ -17,10 +22,10 @@ on:
   workflow_call:
     outputs:
       release_created:
-        description: "'true' when this run just published a release"
+        description: "'true' when this run just cut a release"
         value: ${{ jobs.release-please.outputs.release_created }}
       tag_name:
-        description: The tag of the release that was just published
+        description: The tag of the release that was just cut (a draft-flow config forces the tag at creation, so it is checkout-able before publication)
         value: ${{ jobs.release-please.outputs.tag_name }}
 
 # The effective token comes from the calling job; declaring the needs here

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,13 @@ sources/
 # patterns go in the REPOSITORY LOCAL section above. Managed patterns
 # deliberately come last: last-match-wins makes them non-overridable.
 
+## Agent local state (repo-platform)
+.claude/worktrees/
+.claude/.worktrees/
+.codex/worktrees/
+.worktrees/
+.claude/settings.local.json
+
 ## Windows (github/gitignore Global/Windows.gitignore)
 # Windows thumbnail cache files
 Thumbs.db


### PR DESCRIPTION
Automated template update from [`Vivswan/repo-platform`](https://github.com/Vivswan/repo-platform/tree/staging) (staging channel).

- Previous: `d97a355`
- New: `staging@8816965cc340`

Review any merge conflicts and confirm repository-local sections were preserved before merging.

> [!NOTE]
> This branch is regenerated on every sync run; manual commits
> pushed to it are overwritten. Make fixes in a separate branch or
> after merging.