### PR TITLE
chore: update repo-platform template to staging@70c478026855

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,6 +1,6 @@
 # This file is managed by Vivswan/repo-platform.
 # Copier uses it to track the template source and version - do not delete.
-_commit: facc3d6
+_commit: 70c4780
 _src_path: gh:Vivswan/repo-platform
 channel: staging
 description: 'Turn highlighted text into natural speech with Amazon Polly, Azure,

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -35,6 +35,13 @@ repository:
   allow_auto_merge: true
   enable_vulnerability_alerts: true
   enable_automated_security_fixes: true
+  # Declared so the apply heals out-of-band disables. Public only: without
+  # Advanced Security, private repositories reject this block (422).
+  security_and_analysis:
+    secret_scanning:
+      status: enabled
+    secret_scanning_push_protection:
+      status: enabled
 
 labels:
   - name: dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,8 @@ jobs:
   # scans the event's commit range (fetch-depth: 0 so any range
   # resolves); audit the OLD history once with a local `gitleaks git`.
   # Personal-account repos need no GITLEAKS_LICENSE; allowlist false
-  # positives in a repo-owned .gitleaks.toml at the repository root.
+  # positives in the repo-owned .gitleaks.toml at the repository root
+  # (seeded by the template, never overwritten by sync).
   # pull-requests read: the action lists the PR's commits to build the
   # scan range. Comments off keeps that scope at read; leaks still land
   # in the job summary and SARIF artifact.
@@ -86,10 +87,14 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-      - uses: gitleaks/gitleaks-action@v2
+      - uses: gitleaks/gitleaks-action@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITLEAKS_ENABLE_COMMENTS: "false"
+          # The action's default binary (8.24.3) predates .gitleaks.toml's
+          # minVersion floor AND skips that check silently; pin one meeting
+          # the floor so CI honors the same config local runs do.
+          GITLEAKS_VERSION: "8.30.1"
 
   yamllint:
     runs-on: ubuntu-latest
@@ -99,6 +104,24 @@ jobs:
         run: python3 -m pip install --quiet yamllint
       - name: Lint YAML
         run: yamllint -s .
+
+  # Fails when a PR introduces dependencies with known vulnerabilities, by
+  # diffing the dependency graph between base and head. Public renders only:
+  # the dependency-graph API behind it is free just for public repositories.
+  # Only PR events have a diff to review, so the skip lives on the steps:
+  # all-green treats a skipped needed job as failure, so the job itself
+  # stays unconditional.
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        if: github.event_name == 'pull_request'
+      - uses: actions/dependency-review-action@v5
+        if: github.event_name == 'pull_request'
+        with:
+          # Deliberate strictest threshold (also the action's default,
+          # pinned so a default change cannot loosen the gate silently).
+          fail-on-severity: low
 
   # CodeQL analysis runs inside the gate (one job per language), so a failed
   # scan blocks merges. Each job grants the scan permissions - a caller
@@ -114,6 +137,34 @@ jobs:
       security-events: write
       actions: read
 
+
+  # Fails when the release-please PR head lacks main's tip at CHECK time:
+  # a stale release PR cuts a release whose version and changelog miss
+  # commits already on main. A main push after this run is only caught by
+  # release-please's refresh re-running CI. Other PRs stay mergeable while
+  # behind (required checks are not strict). The skip lives on the STEPS:
+  # all-green treats a skipped needed job as failure.
+  release-freshness:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        if: github.event_name == 'pull_request' && startsWith(github.head_ref, 'release-please--')
+        with:
+          # Full history: the ancestor check needs origin/main.
+          fetch-depth: 0
+          # PR head, not the default merge ref - the merge ref already
+          # contains main's tip, so it would always pass.
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Require the release PR to contain the tip of main
+        if: github.event_name == 'pull_request' && startsWith(github.head_ref, 'release-please--')
+        run: |
+          tip="$(git rev-parse "origin/${GITHUB_BASE_REF}")"
+          if git merge-base --is-ancestor "$tip" HEAD; then
+            echo "release PR contains the ${GITHUB_BASE_REF} tip (${tip})"
+          else
+            echo "::error::Release PR is behind ${GITHUB_BASE_REF} (tip ${tip}); its version and changelog would miss commits already on ${GITHUB_BASE_REF}. Do not merge; release-please refreshes the PR after the next green run on ${GITHUB_BASE_REF}."
+            exit 1
+          fi
 
   # Conventional Commit PR title, checked inside the gate so branch
   # protection blocks on it. PRs are squash-merged, so the PR title becomes
@@ -142,7 +193,9 @@ jobs:
       - actionlint
       - gitleaks
       - yamllint
+      - dependency-review
       - codeql-javascript
+      - release-freshness
       - pr-title
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/dependabot-bun-lockfile.yml
+++ b/.github/workflows/dependabot-bun-lockfile.yml
@@ -56,11 +56,11 @@ jobs:
       # Every tracked lockfile, not just the root one: a repository can
       # commit several (repo-platform itself locks each composite action's
       # directory). '*/bun.lock' is a git pathspec, where '*' crosses '/',
-      # so it matches at any depth. Deleting before regenerating matters: bun accepts the
-      # stale lockfile as a valid resolution and keeps it, so only a
-      # from-scratch resolve drops the stale entries. The side effect is a
-      # refresh of every in-range pin, which package.json ranges and the
-      # PR's own CI still bound.
+      # so it matches at any depth. Deleting before regenerating matters:
+      # bun accepts the stale lockfile as a valid resolution and keeps it,
+      # so only a from-scratch resolve drops the stale entries. The side
+      # effect is a refresh of every in-range pin, which package.json
+      # ranges and the PR's own CI still bound.
       - name: Regenerate bun lockfiles
         shell: bash
         run: |

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,83 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at the project owner's GitHub profile ([github.com/Vivswan](https://github.com/Vivswan)). All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,76 +1,42 @@
-# Contributing
+# Contributing to cloud-speech
 
-Thanks for helping improve Cloud Speech!
+Thanks for contributing! This document covers the conventions every change
+in this repository goes through.
 
-## Setup
+CI, settings, and standards files here (including this document above the
+marker at the bottom) are managed by
+[Vivswan/repo-platform](https://github.com/vivswan/repo-platform);
+local edits to managed files are replaced on the next template sync.
 
-```bash
-git clone https://github.com/vivswan/cloud-speech
-cd cloud-speech
-bun install
-bun run dev        # extension dev (browser opens) + website on localhost:5173
-```
+## Pull requests
 
-`bun run dev:extension` runs the extension alone with interactive WXT keys;
-`bun run dev:web` runs only the website.
+- Changes land through pull requests and are squash-merged; the PR title
+  becomes the commit subject on the default branch.
+- The PR title and every pushed commit subject must be a
+  [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/),
+  for example `feat: add X` or `fix(parser): handle Y`. Releases are
+  versioned from these subjects.
 
-## Before you open a PR
+## CI
 
-All of these must pass; CI gates on them via the single `all-green` check:
+- CI gates on a single status check, `all-green`, which needs every
+  gating CI job (the convention is documented in
+  [repo-platform's all-green guide](https://github.com/vivswan/repo-platform/blob/main/docs/all-green.md)).
+- Repository-specific checks live in `.github/workflows/checks.yml`; run
+  the commands it lists locally before pushing.
+- A typography gate enforces plain ASCII punctuation: no curly quotes,
+  em-dashes, or invisible unicode.
 
-```bash
-bun run typecheck      # strict TypeScript, both apps
-bun run check          # biome lint + format, YAML style (check:fix auto-fixes)
-bun run test:coverage  # vitest unit tests with coverage thresholds
-bun run build:chrome && bun run build:firefox  # both browser builds must succeed
-```
+## Security
 
-CI runs these via the repo-owned `.github/workflows/checks.yml`, inside the
-managed `ci.yml` gate from [repo-platform](https://github.com/vivswan/repo-platform),
-which also checks typography (plain ASCII punctuation only), YAML style,
-workflow lint, and CodeQL.
+Never report vulnerabilities in issues or pull requests - see
+[SECURITY.md](SECURITY.md) for the private reporting route.
 
-PR titles AND commit subjects must follow
-[Conventional Commits](https://www.conventionalcommits.org/)
-(`feat:`, `fix:`, `docs:`, `chore:`, and so on). PRs are squash-merged, and the
-title becomes the commit that drives release-please versioning. `feat!:` and
-`fix!:` denote breaking changes.
+## Code of conduct
 
-## Project layout
+Participation in this project is governed by the
+[code of conduct](CODE_OF_CONDUCT.md).
 
-- `apps/extension`: the WXT extension (see `AGENTS.md` for architecture)
-- `apps/web`: the website with setup guides, pricing, troubleshooting, and the
-  privacy policy (Astro, GitHub Pages)
-- `sources/`: the original single-provider forks, kept as read-only reference
-
-## Adding a TTS provider
-
-The whole point of the architecture: a provider is one file.
-
-1. Create `apps/extension/src/providers/<id>.ts` implementing `TtsProvider`
-   (see `types.ts`; `google.ts` is a good REST example, `polly.ts` an SDK one).
-2. Register it with one line in `apps/extension/src/providers/index.ts`.
-3. Add its strings to all four locales in `apps/extension/src/locales/`.
-4. Add a setup guide page at `apps/web/src/pages/setup/<id>.astro` (copy an
-   existing one; Astro routes pages by file path, so there is nothing to
-   register).
-5. Add `buildSsml`/normalization tests under `apps/extension/tests/providers/`.
-
-No provider-specific code goes anywhere else; the UI, storage, and playback
-are registry-driven.
-
-## Localization
-
-Every user-facing string needs a key in `en.yml`, `hi.yml`, `zh_CN.yml`, and
-`zh_TW.yml`. The build fails on missing keys in the default locale; please keep
-the other three in sync rather than leaving English fallbacks.
-
-## Releases (maintainers)
-
-Merging the rolling release-please PR tags a version, builds the chrome and
-firefox zips (plus the AMO-required sources zip) from the tag and attaches them
-to the GitHub release, and publishes the single chrome zip to every Chrome Web
-Store listing ID and the firefox zip to addons.mozilla.org (each skipped until
-its secrets are configured); see `.github/workflows/release.yml`. The website
-redeploys on the release via the managed `pages.yml` (production root from the
-release tag; every push to main also publishes a preview under `/staging/`).
+<!-- Repository-specific contributing documentation (dev setup, build and
+     test commands, review expectations) goes below this line. It survives
+     template updates via three-way merge. -->


### PR DESCRIPTION
Automated template update from [`Vivswan/repo-platform`](https://github.com/Vivswan/repo-platform/tree/staging) (staging channel).

- Previous: `facc3d6`
- New: `staging@70c478026855`

Review any merge conflicts and confirm repository-local sections were preserved before merging.

> [!NOTE]
> This branch is regenerated on every sync run; manual commits
> pushed to it are overwritten. Make fixes in a separate branch or
> after merging.

> [!WARNING]
> copier hit merge conflicts, resolved below in favor of the
> template where possible. Restore any dropped local lines that
> should stay, and hand-edit anything marked unresolved, before
> merging.

#### `CONTRIBUTING.md`

Conflict 1: dropped local lines (template version kept):

````
# Contributing

Thanks for helping improve Cloud Speech!

## Setup

```bash
git clone https://github.com/vivswan/cloud-speech
cd cloud-speech
bun install
bun run dev        # extension dev (browser opens) + website on localhost:5173
```

`bun run dev:extension` runs the extension alone with interactive WXT keys;
`bun run dev:web` runs only the website.

## Before you open a PR

All of these must pass; CI gates on them via the single `all-green` check:

```bash
bun run typecheck      # strict TypeScript, both apps
bun run check          # biome lint + format, YAML style (check:fix auto-fixes)
bun run test:coverage  # vitest unit tests with coverage thresholds
bun run build:chrome && bun run build:firefox  # both browser builds must succeed
```

CI runs these via the repo-owned `.github/workflows/checks.yml`, inside the
managed `ci.yml` gate from [repo-platform](https://github.com/vivswan/repo-platform),
which also checks typography (plain ASCII punctuation only), YAML style,
workflow lint, and CodeQL.

PR titles AND commit subjects must follow
[Conventional Commits](https://www.conventionalcommits.org/)
(`feat:`, `fix:`, `docs:`, `chore:`, and so on). PRs are squash-merged, and the
title becomes the commit that drives release-please versioning. `feat!:` and
`fix!:` denote breaking changes.

## Project layout

- `apps/extension`: the WXT extension (see `AGENTS.md` for architecture)
- `apps/web`: the website with setup guides, pricing, troubleshooting, and the
  privacy policy (Astro, GitHub Pages)
- `sources/`: the original single-provider forks, kept as read-only reference

## Adding a TTS provider

The whole point of the architecture: a provider is one file.

1. Create `apps/extension/src/providers/<id>.ts` implementing `TtsProvider`
   (see `types.ts`; `google.ts` is a good REST example, `polly.ts` an SDK one).
2. Register it with one line in `apps/extension/src/providers/index.ts`.
3. Add its strings to all four locales in `apps/extension/src/locales/`.
4. Add a setup guide page at `apps/web/src/pages/setup/<id>.astro` (copy an
   existing one; Astro routes pages by file path, so there is nothing to
   register).
5. Add `buildSsml`/normalization tests under `apps/extension/tests/providers/`.

No provider-specific code goes anywhere else; the UI, storage, and playback
are registry-driven.

## Localization

Every user-facing string needs a key in `en.yml`, `hi.yml`, `zh_CN.yml`, and
`zh_TW.yml`. The build fails on missing keys in the default locale; please keep
the other three in sync rather than leaving English fallbacks.

## Releases (maintainers)

Merging the rolling release-please PR tags a version, builds the chrome and
firefox zips (plus the AMO-required sources zip) from the tag and attaches them
to the GitHub release, and publishes the single chrome zip to every Chrome Web
Store listing ID and the firefox zip to addons.mozilla.org (each skipped until
its secrets are configured); see `.github/workflows/release.yml`. The website
redeploys on the release via the managed `pages.yml` (production root from the
release tag; every push to main also publishes a preview under `/staging/`).
````