### PR TITLE
chore: update repo-platform template to staging@ce948109380e

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,6 +1,6 @@
 # This file is managed by Vivswan/repo-platform.
 # Copier uses it to track the template source and version - do not delete.
-_commit: 74296e4
+_commit: ce94810
 _src_path: gh:Vivswan/repo-platform
 channel: staging
 copyright_holder: Vivswan Shah (https://github.com/Vivswan)

--- a/.gitattributes
+++ b/.gitattributes
@@ -7,9 +7,6 @@ CLAUDE.md -text
 .github/copilot-instructions.md -text
 .github/agents.md -text
 
-# Render the extensionless LICENSE as Markdown on GitHub.
-LICENSE linguist-language=Markdown
-
 # Keep binary assets byte-for-byte unchanged.
 *.ico binary
 *.jpg binary
@@ -19,3 +16,7 @@ LICENSE linguist-language=Markdown
 *.webp binary
 *.pdf binary
 *.zip binary
+
+# Repository-specific attributes (binary globs, linguist overrides) go
+# below this line. They survive template updates via three-way merge.
+# repo-platform:local-section

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,9 @@ jobs:
   # scan blocks merges. Each job grants the scan permissions - a caller
   # job's permissions are the ceiling for the called workflow - and the
   # weekly re-scan schedule lives on this workflow's triggers.
+  # Repo-specific scan tuning (paths-ignore, extra queries, packs) goes in
+  # the repo-owned .github/codeql/codeql-config.yml - the standard CodeQL
+  # config file, picked up automatically when present.
 
   codeql-javascript:
     uses: Vivswan/repo-platform/.github/workflows/reusable-codeql.yml@main

--- a/.typography-allow
+++ b/.typography-allow
@@ -5,3 +5,4 @@
 # release-please writes CHANGELOG.md from commit and PR text, which is not
 # ASCII-guaranteed.
 CHANGELOG.md
+# END REPO-PLATFORM MANAGED

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,11 +41,12 @@ Cloud Speech: Turn highlighted text into natural speech with Amazon Polly, Azure
   `settings/repos/` file named after this repository over there when one
   exists, otherwise by this repository's own `.github/settings.yml`. Do not
   change settings by hand in the GitHub UI; edit the settings file.
-- Repo-owned escape hatches stay local: `.github/workflows/checks.yml` and
-  `.github/workflows/release.yml`, `.gitignore`'s marked LOCAL section,
-  `.typography-allow.local` (typography exemptions; the managed
-  `.typography-allow` is overwritten by sync), and the repository-specific
-  section below.
+- Repo-owned escape hatches stay local:
+  `.github/workflows/checks.yml`,
+  `.github/workflows/release.yml`, `.gitleaks.toml`,
+  `.gitignore`'s marked LOCAL section, `.typography-allow.local`
+  (typography exemptions; the managed `.typography-allow` is overwritten
+  by sync), and the repository-specific section below.
 - Module selection is this repository's own: edit the `modules` list in
   `.repo-platform.yml` and the next sync PR applies the change.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ local edits to managed files are replaced on the next template sync.
   versioned from these subjects.
 - By opening a pull request, or offering code in an issue or review for
   inclusion, you agree to the Contributions section of the
-  [LICENSE](LICENSE), which licenses that code to the licensor -
+  [LICENSE](LICENSE.md), which licenses that code to the licensor -
   including for relicensing under any terms - unless you conspicuously
   say otherwise when you submit it.
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 # Individual and Small Organization License 1.0.0
 
-<https://github.com/Vivswan/repo-platform/blob/main/LICENSE>
+<https://github.com/Vivswan/repo-platform/blob/main/LICENSE.md>
 
 Required Notice: Copyright Vivswan Shah (https://github.com/Vivswan)
 
@@ -344,8 +344,3 @@ licenses.
      third-party components, differently licensed paths) go below this
      line. They survive template updates via three-way merge. -->
 <!-- repo-platform:local-section -->
-
-## Earlier Versions
-
-Releases of this software through v1.0.8 were published under the MIT
-License and remain available under it.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Chrome Web Store](https://img.shields.io/chrome-web-store/v/kdcbeehimalgmeoeajnflggejlemclnn.svg)](https://chromewebstore.google.com/detail/kdcbeehimalgmeoeajnflggejlemclnn)
 [![GitHub Pages](https://img.shields.io/badge/website-cloud--speech-blue)](https://vivswan.github.io/cloud-speech/)
-[![License](https://img.shields.io/badge/license-source--available-blue)](LICENSE)
+[![License](https://img.shields.io/badge/license-source--available-blue)](LICENSE.md)
 
 Turn highlighted text on any web page into natural speech using multiple cloud text-to-speech
 providers (Amazon Polly, Azure Speech, Google Cloud TTS, and OpenAI) from a single extension.
@@ -75,7 +75,7 @@ registry line + locale strings + a setup guide page on the website.
 
 ## License
 
-Individual and Small Organization License 1.0.0; see [LICENSE](LICENSE).
+Individual and Small Organization License 1.0.0; see [LICENSE](LICENSE.md).
 Free for individuals (any purpose, including freelance work); small
 organizations may use it internally; anything beyond that needs the
 licensor's permission. Releases through v1.0.8 were published under the

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -20,7 +20,7 @@
     "test:e2e": "playwright test"
   },
   "author": "Vivswan Shah",
-  "license": "SEE LICENSE IN LICENSE",
+  "license": "SEE LICENSE IN LICENSE.md",
   "dependencies": {
     "@aws-sdk/client-polly": "^3.1093.0",
     "@cloud-speech/constants": "workspace:*",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "*.{ts,tsx,js,mjs,json,astro}": "biome check --write --no-errors-on-unmatched"
   },
   "author": "Vivswan Shah",
-  "license": "SEE LICENSE IN LICENSE",
+  "license": "SEE LICENSE IN LICENSE.md",
   "devDependencies": {
     "@biomejs/biome": "2.5.5",
     "husky": "^9.1.7",


### PR DESCRIPTION
Automated template update from [`Vivswan/repo-platform`](https://github.com/Vivswan/repo-platform/tree/staging) (staging channel).

- Previous: `74296e4`
- New: `staging@ce948109380e`

Supersedes #93, which GitHub auto-closed (and would not reopen) when `main` was force-pushed during the history rewrite; this branch is the same template update rebased onto the rewritten `main`.

Review any merge conflicts and confirm repository-local sections were preserved before merging.

> [!NOTE]
> This branch is regenerated on every sync run; manual commits
> pushed to it are overwritten. Make fixes in a separate branch or
> after merging.

The license-transition warnings from #93 are resolved on this branch; see the comment below.
